### PR TITLE
Przekazywanie opcji do klienta soap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 composer.lock
 .DS_Store
+/env.php

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,9 @@
     "autoload": {
         "psr-4": {
             "Aftermarketpl\\CompanyLookup\\": "src/"
-        },
+        }
+    },
+    "autoload-dev": {
         "files": ["env.php"]
     },
     "minimum-stability": "dev",

--- a/src/ViesReader.php
+++ b/src/ViesReader.php
@@ -24,10 +24,8 @@ class ViesReader
      */
     public function __construct($options = [])
     {
-        $this->options = $options;
-    
         try {
-            $this->api = new SoapClient($this->ws_url);
+            $this->api = new SoapClient($this->ws_url, $options);
         } catch(\Throwable $e) {
             throw new ViesReaderException('Checking status currently not available');
         }

--- a/tests/ViesTest.php
+++ b/tests/ViesTest.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+use Aftermarketpl\CompanyLookup\Exceptions\ViesReaderException;
+use Aftermarketpl\CompanyLookup\ViesReader;
 use PHPUnit\Framework\TestCase;
 
 final class ViesTest extends TestCase
@@ -49,5 +51,21 @@ final class ViesTest extends TestCase
     {
         $response = self::$reader->lookup('IE3232319JH');
         $this->assertTrue($response->valid);
+    }
+
+    public function testClientOptionsArePassed(): void
+    {
+        $invalidOptions = [
+            'location' => '127.0.0.1',
+        ];
+
+        $reader = new ViesReader($invalidOptions);
+
+        try {
+            $reader->lookup('PL9121875009');
+            $this->fail('SoapClient should throw exception');
+        } catch (ViesReaderException $e) {
+            $this->addToAssertionCount(1);
+        }
     }
 }


### PR DESCRIPTION
Opcje przekazywane do kostruktora ViesReader nie sa obecnie uzywane.